### PR TITLE
NPE when releasing camera

### DIFF
--- a/scanner/src/main/java/com/bobekos/bobek/scanner/scanner/BarcodeScanner.kt
+++ b/scanner/src/main/java/com/bobekos/bobek/scanner/scanner/BarcodeScanner.kt
@@ -59,7 +59,7 @@ internal class BarcodeScanner(
 
                     emitter.setCancellable {
                         updateDisposable?.dispose()
-                        camera.getCameraSource()?.release()
+                        camera.releaseCameraSource()
                     }
 
                     updateDisposable = updateSubject.subscribe({ camera.setParametersFromConfig() }, {})

--- a/scanner/src/main/java/com/bobekos/bobek/scanner/scanner/Camera.kt
+++ b/scanner/src/main/java/com/bobekos/bobek/scanner/scanner/Camera.kt
@@ -97,4 +97,10 @@ internal class Camera(private val ctx: Context?, private val config: BarcodeScan
         return cameraSource
     }
 
+    fun releaseCameraSource() {
+        try {
+            cameraSource?.release()
+        } catch (ignored: NullPointerException) {
+        }
+    }
 }


### PR DESCRIPTION
@bobekos When using scanner with fragments and compositedisposable, I sometimes faced same issue as described [here](https://github.com/googlesamples/android-vision/issues/184). I've applied the same solution as discussed in the github discussion. 
It works in my case, but I didn't test it too broadly so it might require some additional confirmation.  